### PR TITLE
prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.0.0 – 2024-07-21
+
+### Added
+
+- Watercolor tile server
+
+### Changed
+
+- Use latest nextcloud/vue library
+- Set min and max NC version to 30
+
 ## 1.0.12 – 2024-03-04
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[OpenStreetMap integration provides a search provider for locations, a reference
 provider to render location links from various map services (OpenStreetMap, Google maps...) and a custom link picker
 component to quickly insert a location link by searching or selecting a point on an (awesome) interactive map.]]></description>
-	<version>1.0.12</version>
+	<version>2.0.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Osm</namespace>


### PR DESCRIPTION
### Added

- Watercolor tile server

### Changed

- Use latest nextcloud/vue library
- Set min and max NC version to 30