### PR TITLE
Prepare 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 4.1.0 – 2026-03-27
+
+### Changed
+
+- All the reference providers now implement IPublicReferenceProvider
+- Remove default maptiler key
+
+### Fixed
+
+- Do not proxy on public pages
+- Add required csp when proxy is disabled (we access OSM/MapTiler directly)
+- Do not query user config with IUserConfig in public contexts (listeners) @julien-nc [#61](https://github.com/nextcloud/integration_openstreetmap/pull/61)
+- Remove unused userId in OsmAPIService
+- Do not save map state in public pages
+- Proxy maptiler logo URL only if needed
+- Always fallback to the osmRaster style when no key is set, do not add vector styles when no key is set
+- Hide all terrain stuff if no api key set
+- Add referer header in map requests now enforced by OSM
+
 ## 4.0.1 – 2026-03-26
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[OpenStreetMap integration provides a search provider for locations, a reference
 provider to render location links from various map services (OpenStreetMap, Google maps...) and a custom link picker
 component to quickly insert a location link by searching or selecting a point on an (awesome) interactive map.]]></description>
-	<version>4.0.1</version>
+	<version>4.1.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Osm</namespace>


### PR DESCRIPTION
### Changed

- All the reference providers now implement IPublicReferenceProvider
- Remove default maptiler key

### Fixed

- Do not proxy on public pages
- Add required csp when proxy is disabled (we access OSM/MapTiler directly)
- Do not query user config with IUserConfig in public contexts (listeners) @julien-nc [#61](https://github.com/nextcloud/integration_openstreetmap/pull/61)
- Remove unused userId in OsmAPIService
- Do not save map state in public pages
- Proxy maptiler logo URL only if needed
- Always fallback to the osmRaster style when no key is set, do not add vector styles when no key is set
- Hide all terrain stuff if no api key set
- Add referer header in map requests now enforced by OSM