### PR TITLE
prepare 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 4.2.0 – 2026-07-21
+
+### Changed
+
+- Bump max NC version to 35 @julien-nc
+- Polish UI, smaller button icons, make NcSelect non-clearable @julien-nc
+- Update dependencies @julien-nc [#80](https://github.com/nextcloud/integration_openstreetmap/pull/80)
+- Update npm and composer dependencies @julien-nc
+
 ## 4.1.0 – 2026-03-27
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[OpenStreetMap integration provides a search provider for locations, a reference
 provider to render location links from various map services (OpenStreetMap, Google maps...) and a custom link picker
 component to quickly insert a location link by searching or selecting a point on an (awesome) interactive map.]]></description>
-	<version>4.1.0</version>
+	<version>4.2.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Osm</namespace>


### PR DESCRIPTION
### Changed

- Bump max NC version to 35 @julien-nc
- Polish UI, smaller button icons, make NcSelect non-clearable @julien-nc
- Update dependencies @julien-nc [#80](https://github.com/nextcloud/integration_openstreetmap/pull/80)
- Update npm and composer dependencies @julien-nc